### PR TITLE
Fix Mermaid relay test diagram line break

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,9 @@ Here are the next steps I'm planning to work on:
 ## Contact
 
 If you'd like to collaborate or have any tips, feel free to reach out to me on GitHub!
+
+## Relay Test Diagram
+
+```mermaid
+D([Perform bypass relay test<br>(midpoint bed)])
+```


### PR DESCRIPTION
## Summary
- replace newline with `<br/>` in Mermaid relay test node to avoid parse errors

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5909ecdc832288dbc8a631356fae